### PR TITLE
Fix Join and History Page Images on Mobile

### DIFF
--- a/history.html
+++ b/history.html
@@ -63,9 +63,9 @@
                     The dojo is run by Sensei Bruce Nguyen and Sensei Chad Eagan,
                     the instructors of the affiliated ARC class.
                 </p>
-                <img src="images/history_1.jpg" style="width: 40%; float: left; margin: 40px 40px 40px 0;">
-                <p style="margin-left: 45%;">NKC has made a number of accomplishments since its establishment, including:</p>
-                <ul style="margin-left: 45%;">
+                <img src="images/history_1.jpg" class="content-image left">
+                <p>NKC has made a number of accomplishments since its establishment, including:</p>    
+                <ul>
                     <li>
                         1st place at the Collegiate PATMA Tournament at UC San Diego on April 2009.
                         Our members also participated in the open competition, winning a total of 6 medals.

--- a/join.html
+++ b/join.html
@@ -49,7 +49,7 @@
             </nav>
         </header>
         <main>
-            <div class="page-image" style="background-image: url(images/karatezoom.jpg); background-position: 0% 55%;"></div>
+            <div class="page-image" style="background-image: url(images/karatezoom.jpg); background-position: center; background-size: contain;"></div>
             <div class="title-banner">
                 <img src="images/banners/banner-join.png">
             </div>
@@ -78,7 +78,7 @@
                     that simulates a real fight. Last but not least, kumite means “sparring” and this is when we execute our
                     live knowledge in engaging an opponent with what we have learned.
                 </p>
-                <img src="images/karate_week1_practice.jpg" style="float: right; height: 600px; margin: 10px 0 40px 40px;">
+                <img src="images/karate_week1_practice.jpg" class="content-image right">
                 <h3><b>Why should I learn karate?</b></h3>
                 <p>There are numerous physical, mental, and social benefits for learning karate.</p>
                 <ul>
@@ -154,7 +154,7 @@
                         training session. Instead, we are using an application called Zoom and have our
                         Sensei or Senpai teach us online. Our current schedule is Wednesday 6:00-7:00 PM
                         and Saturday 10:00-11:00 AM and 1:00-2:30 PM. Anyone is welcome to join, and feel
-                        free to reach out to us at <a href = "mailto: karate@uci.edu">karate@uci.edu</a> for more information.
+                        free to reach out to us at <a href="mailto: karate@uci.edu">karate@uci.edu</a> for more information.
                     </strong>
                 </p>
                 <p>
@@ -166,12 +166,13 @@
                 <h3><b>I'm not sure about this whole karate thing...</b></h3>
                 <p>
 				    Don't worry, we've all been there. If you're still on the fence, then we'd recommend dropping by one of our Zoom practices.
-                    Shoot an email to the officers <a href = "mailto: karate@uci.edu">karate@uci.edu</a>, and we’ll help you get set up!
+                    Shoot an email to the officers <a href="mailto: karate@uci.edu">karate@uci.edu</a>, and we’ll help you get set up!
                 </p>
                 <h3><b>I have some other questions.</b></h3>
                 <p>
-                    Feel free to send an email to the officers at <a href = "mailto: karate@uci.edu">karate@uci.edu</a>, and we'll be happy to answer any of your additional
-                  questions. If you’re interested in learning more about us, come check out our <a href="https://www.instagram.com/ucikarate/">Instagram</a> and <a href="https://www.facebook.com/groups/ucikarate">Facebook</a> pages.
+                    Feel free to send an email to the officers at <a href="mailto: karate@uci.edu">karate@uci.edu</a>, and we'll be happy to answer any of your additional
+                    questions. If you’re interested in learning more about us, come check out our <a href="https://www.instagram.com/ucikarate/">Instagram</a> and
+                    <a href="https://www.facebook.com/groups/ucikarate">Facebook</a> pages.
                 </p>
             </div>
         </main>

--- a/styles/index.css
+++ b/styles/index.css
@@ -395,6 +395,12 @@ header {
     background-color: rgb(245, 245, 245, 0.4);
 }
 
+/* Images for content pages */
+.content-image {
+    padding: 40px;
+    width: 50%;
+}
+
 /* Content sections (as seen on home page) */
 .section {
     padding-bottom: 1rem;
@@ -418,7 +424,7 @@ header {
     display: inline-block;
 }
 
-/* Title for content pages */
+/* Text for content pages */
 .page-content {
     height: 100%;
     font-size: 1.1rem;
@@ -448,10 +454,18 @@ header {
         border-radius: 0 15px 15px 0;
     }
 
-    /* Header for content pages */
+    /* Text for content pages */
     .page-content {
         width: 65%;
         margin: 75px 17.5% 75px 17.5%;
+    }
+
+    /* Images for content pages */
+    .content-image.right {
+        float: right;
+    }
+    .content-image.left {
+        float: left;
     }
 
     /* Content sections (as seen on home page) */
@@ -471,7 +485,7 @@ header {
 @media only screen and (max-width: 872px) {
     /* Image at the top of the page */
     .page-image {
-        max-height: 17rem;
+        height: 17rem;
     }
 
     /* Title for content pages */
@@ -489,6 +503,13 @@ header {
         width: 80%;
         margin: 0;
         padding: 2rem 10% 4rem 10%;
+    }
+
+    /* Images for content pages */
+    .content-image {
+        width: 100%;
+        padding: 0;
+        float: center;
     }
 
     /* Use with anchor tags to jump below header */


### PR DESCRIPTION
Added a CSS class for images on content pages.

The `content-image` should automatically center the image on mobile and adding the `left` or `right` class will float it left or right respectively on desktop only.